### PR TITLE
fix: correct presence tracking

### DIFF
--- a/mainmenu.html
+++ b/mainmenu.html
@@ -87,6 +87,10 @@
     const partyCount  = (room) => Array.isArray(room?.partyUids) ? room.partyUids.length : 0;
     const includesMe  = (uid, room) => Array.isArray(room?.partyUids) ? room.partyUids.includes(uid) : false;
 
+    // presence heartbeat
+    let presenceTimer = null;
+    const PRESENCE_INTERVAL = 30000; // 30s
+
     // ---------- Navigation ----------
     function routeToPartySelect(roomId){
       const url = `partyselect.html?roomId=${roomId}`;
@@ -118,9 +122,12 @@
           loginBtn.style.display = 'none';
           logoutBtn.style.display = 'inline-block';
           await upsertPresence('MainMenu');
+          if (presenceTimer) clearInterval(presenceTimer);
+          presenceTimer = setInterval(() => upsertPresence('MainMenu'), PRESENCE_INTERVAL);
           renderMyBanner();
           refreshFriends();
         } else {
+          if (presenceTimer) { clearInterval(presenceTimer); presenceTimer = null; }
           namePill.style.display = 'none';
           loginBtn.style.display = 'inline-block';
           logoutBtn.style.display = 'none';
@@ -149,6 +156,7 @@
         try {
           await setDoc(doc(db,'presence', me.uid), clean({ online:false, lastOnline: serverTimestamp() }), { merge:true });
         } catch {}
+        try { clearInterval(presenceTimer); } catch {}
       });
     });
 
@@ -374,7 +382,9 @@
       const presRef = doc(db,'presence', friend.id);
       const unsubPresence = onSnapshot(presRef, async (snap) => {
         const p = snap.exists() ? snap.data() : {};
-        currentPresence = { online: !!p.online, screen: p.screen || null };
+        const updatedAt = p?.updatedAt?.toDate ? p.updatedAt.toDate() : null;
+        const fresh = updatedAt && (Date.now() - updatedAt.getTime() < 60000);
+        currentPresence = { online: !!p.online && fresh, screen: p.screen || null };
         presenceBtn.textContent = currentPresence.online ? 'Online' : 'Offline';
         presenceBtn.className   = 'status-btn status-disabled';
         try { await refreshFriendSession(); } catch {}

--- a/partyselect.html
+++ b/partyselect.html
@@ -69,12 +69,22 @@
 
     let me = null;
     let unsubRoom = null;
+    let presenceTimer = null;
+    const PRESENCE_INTERVAL = 30000;
+    let leavingPage = false;
+
+    async function updatePresence(){
+      const me = auth.currentUser; if(!me) return;
+      try { await setDoc(doc(db,'presence', me.uid), clean({ online:true, screen:'PartySelect', updatedAt: serverTimestamp() }), { merge:true }); } catch {}
+    }
 
     onAuthStateChanged(auth, async (user) => {
       if (!user) { location.href = 'mainmenu.html'; return; }
       me = user;
 
-      try { await setDoc(doc(db,'presence', me.uid), clean({ online:true, screen:'PartySelect', updatedAt: serverTimestamp() }), { merge:true }); } catch {}
+      await updatePresence();
+      if (presenceTimer) clearInterval(presenceTimer);
+      presenceTimer = setInterval(updatePresence, PRESENCE_INTERVAL);
 
       mount();
     });
@@ -265,6 +275,7 @@
     }
 
     async function leaveAndBack(){
+      leavingPage = true;
       try {
         const ref = doc(db,'rooms', roomId);
         const snap = await getDoc(ref);
@@ -277,10 +288,13 @@
         }
       } catch {}
       try { await setDoc(doc(db,'presence', me.uid), clean({ online:true, screen:'MainMenu', updatedAt: serverTimestamp() }), { merge:true }); } catch {}
+      try { clearInterval(presenceTimer); } catch {}
+      try { unsubRoom && unsubRoom(); } catch {}
       location.href = 'mainmenu.html';
     }
 
     window.addEventListener('beforeunload', async () => {
+      if (leavingPage) return;
       try {
         const ref = doc(db,'rooms', roomId);
         const snap = await getDoc(ref);
@@ -290,8 +304,9 @@
           await updateDoc(ref, clean({ partyUids: arrayRemove(me.uid), readyUids: arrayRemove(me.uid), updatedAt: serverTimestamp() }));
         }
       } catch {}
-      try { await setDoc(doc(db,'presence', me.uid), clean({ online:true, screen:'MainMenu', updatedAt: serverTimestamp() }), { merge:true }); } catch {}
+      try { await setDoc(doc(db,'presence', me.uid), clean({ online:false, lastOnline: serverTimestamp() }), { merge:true }); } catch {}
       try { unsubRoom && unsubRoom(); } catch {}
+      try { clearInterval(presenceTimer); } catch {}
     });
   </script>
 </head>


### PR DESCRIPTION
## Summary
- add presence heartbeat and stale check to prevent ghost online status
- set party select unload to mark users offline and clean resources

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc79cce348324ae7c8c56a6ba92c1